### PR TITLE
for Matlab 2014a or earlier Matlab version

### DIFF
--- a/examples/IGA/solidIGAex1.m
+++ b/examples/IGA/solidIGAex1.m
@@ -2,7 +2,9 @@ clear all; close all; clc;
 
 %% Load data
 count=1;
-run ./../NURBS/solid/data_solid6
+% run ./../NURBS/solid/data_solid6
+addpath ../NURBS/Solid
+run data_solid6
 % run ./../NURBS/solid/data_solid7
 deg.p = p; deg.q=q; deg.r = r; clear p q r
 


### PR DESCRIPTION
In Matlab 2014a: run ./../NURBS/solid/data_solid6 line of codes is **not working** 
Error using run (line 39)
.\..\NURBS\solid\data_solid6 not found.
Error in solid (line 10)
run ./../NURBS/solid/data_solid6